### PR TITLE
Add DashScope WAN video studio web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ No requiere Node, Composer ni frameworks adicionales.
    <?php
    define('DASH_SCOPE_API_KEY', 'TU_CLAVE_DASHSCOPE');
    ```
-   También puedes usar la variable de entorno `DASHSCOPE_API_KEY` si tu hosting lo permite.
+   También puedes usar las variables de entorno `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite.
 3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).
 
 ## Uso

--- a/README.md
+++ b/README.md
@@ -1,2 +1,44 @@
-# gestio
-programa de gestion 
+# WAN Video Studio (DashScope International)
+
+Aplicación web mínima en PHP + HTML + CSS + JS pensada para hosting compartido (por ejemplo Hostinger) que permite:
+
+- Generar video texto → video (t2v) con modelos WAN.
+- Generar video imagen → video (i2v) con los modelos WAN.
+- Conversar con modelos Qwen en un chat síncrono.
+
+## Requisitos
+
+- PHP 8.0 o superior con cURL habilitado.
+- Clave de API de [Alibaba Cloud DashScope International Edition](https://dashscope-intl.aliyuncs.com/).
+
+No requiere Node, Composer ni frameworks adicionales.
+
+## Instalación
+
+1. Copia la carpeta `public` al directorio público de tu hosting.
+2. Renombra `public/api/config.sample.php` a `config.php` y añade tu clave:
+   ```php
+   <?php
+   define('DASH_SCOPE_API_KEY', 'TU_CLAVE_DASHSCOPE');
+   ```
+   También puedes usar la variable de entorno `DASHSCOPE_API_KEY` si tu hosting lo permite.
+3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).
+
+## Uso
+
+- **Texto → Video**: Escribe el prompt, elige formato (YouTube 16:9, TikTok 9:16 o cuadrado) y envía. Se mostrará una tarjeta de progreso con actualización periódica del estado hasta obtener la URL del video.
+- **Imagen → Video**: Carga una imagen base, añade el prompt y formato deseado. El archivo se transforma a Base64 y se envía a DashScope.
+- **Chat Qwen**: Interfaz simple para consultas rápidas con respuesta inmediata.
+
+Si ocurre un error, la tarjeta de estado lo mostrará en rojo con el mensaje devuelto por la API.
+
+## Personalización
+
+- Modifica `public/assets/css/style.css` para ajustar la apariencia.
+- Ajusta modelos o parámetros en `public/api/dashscope_client.php` según la versión del modelo WAN/Qwen que prefieras.
+
+## Seguridad
+
+- Mantén tu `config.php` fuera del control de versiones.
+- Asegúrate de usar HTTPS en producción.
+- Limita el tamaño máximo de subida de archivos (e.g., en `.htaccess` o `php.ini`).

--- a/README.md
+++ b/README.md
@@ -21,8 +21,13 @@ No requiere Node, Composer ni frameworks adicionales.
    <?php
    define('DASH_SCOPE_API_KEY', 'TU_CLAVE_DASHSCOPE');
    ```
-   Si tu hosting no permite crear archivos nuevos, puedes editar directamente `config.sample.php` con tu clave; la aplicación
-   cargará cualquiera de los dos siempre que el valor no sea el texto por defecto. También puedes usar las variables de entorno
+   Si lo prefieres, también puedes declarar una variable global en vez del `define`:
+   ```php
+   <?php
+   $DASH_SCOPE_API_KEY = 'TU_CLAVE_DASHSCOPE';
+   ```
+   Si tu hosting no permite crear archivos nuevos, edita directamente `config.sample.php` con cualquiera de las dos opciones; la
+   aplicación cargará ambos archivos siempre que el valor no sea el texto por defecto. También puedes usar las variables de entorno
    `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite; la aplicación las buscará automáticamente tanto en `getenv()`
    como en los arreglos `$_ENV` y `$_SERVER`.
 3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ No requiere Node, Composer ni frameworks adicionales.
    <?php
    define('DASH_SCOPE_API_KEY', 'TU_CLAVE_DASHSCOPE');
    ```
-   También puedes usar las variables de entorno `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite.
+   También puedes usar las variables de entorno `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite; la aplicación
+   las buscará automáticamente tanto en `getenv()` como en los arreglos `$_ENV` y `$_SERVER`.
 3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).
 
 ## Uso

--- a/README.md
+++ b/README.md
@@ -16,13 +16,15 @@ No requiere Node, Composer ni frameworks adicionales.
 ## Instalación
 
 1. Copia la carpeta `public` al directorio público de tu hosting.
-2. Renombra `public/api/config.sample.php` a `config.php` y añade tu clave:
+2. Copia `public/api/config.sample.php` a `config.php` y añade tu clave:
    ```php
    <?php
    define('DASH_SCOPE_API_KEY', 'TU_CLAVE_DASHSCOPE');
    ```
-   También puedes usar las variables de entorno `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite; la aplicación
-   las buscará automáticamente tanto en `getenv()` como en los arreglos `$_ENV` y `$_SERVER`.
+   Si tu hosting no permite crear archivos nuevos, puedes editar directamente `config.sample.php` con tu clave; la aplicación
+   cargará cualquiera de los dos siempre que el valor no sea el texto por defecto. También puedes usar las variables de entorno
+   `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite; la aplicación las buscará automáticamente tanto en `getenv()`
+   como en los arreglos `$_ENV` y `$_SERVER`.
 3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).
 
 ## Uso

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ No requiere Node, Composer ni frameworks adicionales.
    aplicación cargará ambos archivos siempre que el valor no sea el texto por defecto. También puedes usar las variables de entorno
    `DASH_SCOPE_API_KEY` o `DASHSCOPE_API_KEY` si tu hosting lo permite; la aplicación las buscará automáticamente tanto en `getenv()`
    como en los arreglos `$_ENV` y `$_SERVER`.
+   Cuando recibas errores 404 de la API es probable que tu cuenta use rutas distintas; en ese caso descomenta y ajusta en `config.php`
+   la constante `DASH_SCOPE_API_ENDPOINT` y las listas `$DASH_SCOPE_VIDEO_TASK_CREATE_PATHS` / `$DASH_SCOPE_VIDEO_TASK_STATUS_PATHS`
+   para que apunten a los endpoints reales que te indique la documentación de tu región.
 3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).
 
 ## Uso

--- a/README.md
+++ b/README.md
@@ -33,6 +33,13 @@ No requiere Node, Composer ni frameworks adicionales.
    Cuando recibas errores 404 de la API es probable que tu cuenta use rutas distintas; en ese caso descomenta y ajusta en `config.php`
    la constante `DASH_SCOPE_API_ENDPOINT` y las listas `$DASH_SCOPE_VIDEO_TASK_CREATE_PATHS` / `$DASH_SCOPE_VIDEO_TASK_STATUS_PATHS`
    para que apunten a los endpoints reales que te indique la documentación de tu región.
+   Si la API responde `Model not exist` o mensajes parecidos, redefine `DASH_SCOPE_MODEL_T2V` y/o `DASH_SCOPE_MODEL_I2V` en `config.php`.
+   Puedes asignar un string con el modelo correcto o un arreglo con varios candidatos, por ejemplo:
+   ```php
+   <?php
+   $DASH_SCOPE_MODEL_T2V = ['wanx-v1.1-t2v', 'wanx-v1-t2v'];
+   $DASH_SCOPE_MODEL_I2V = 'wanx-v1.2-i2v';
+   ```
 3. Asegúrate de que la carpeta `public/uploads` tenga permisos de escritura si planeas guardar imágenes (por defecto solo se usan temporalmente).
 
 ## Uso

--- a/public/api/bootstrap.php
+++ b/public/api/bootstrap.php
@@ -1,0 +1,29 @@
+<?php
+declare(strict_types=1);
+
+if (!function_exists('dashscope_load_configuration')) {
+    function dashscope_load_configuration(): void
+    {
+        static $loaded = false;
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        $baseDir = __DIR__;
+        $candidates = [
+            'config.php',
+            'config.local.php',
+            'config.sample.php',
+        ];
+
+        foreach ($candidates as $file) {
+            $path = $baseDir . '/' . $file;
+            if (is_file($path)) {
+                require_once $path;
+            }
+        }
+    }
+}
+
+dashscope_load_configuration();

--- a/public/api/chat.php
+++ b/public/api/chat.php
@@ -1,0 +1,53 @@
+<?php
+declare(strict_types=1);
+
+$maybeConfig = __DIR__ . '/config.php';
+if (file_exists($maybeConfig)) {
+    require_once $maybeConfig;
+}
+require_once __DIR__ . '/dashscope_client.php';
+
+header('Content-Type: application/json');
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        throw new RuntimeException('Invalid request method.');
+    }
+
+    $data = json_decode(file_get_contents('php://input'), true);
+    if (!is_array($data)) {
+        throw new RuntimeException('JSON inválido.');
+    }
+
+    $message = trim($data['message'] ?? '');
+    if ($message === '') {
+        throw new RuntimeException('El mensaje es obligatorio.');
+    }
+
+    $systemPrompt = isset($data['system']) ? trim((string)$data['system']) : null;
+
+    $response = dashscope_chat($message, $systemPrompt);
+
+    $choices = $response['output']['choices'] ?? [];
+    $assistantText = '';
+    if ($choices) {
+        $assistantMessage = $choices[0]['message']['content'] ?? '';
+        if (is_array($assistantMessage)) {
+            $assistantText = implode("\n", array_column($assistantMessage, 'text'));
+        } else {
+            $assistantText = (string)$assistantMessage;
+        }
+    }
+
+    echo json_encode([
+        'success' => true,
+        'message' => $assistantText,
+        'raw' => $response,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => $e->getMessage(),
+    ]);
+}

--- a/public/api/chat.php
+++ b/public/api/chat.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-$maybeConfig = __DIR__ . '/config.php';
-if (file_exists($maybeConfig)) {
-    require_once $maybeConfig;
-}
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/dashscope_client.php';
 
 header('Content-Type: application/json');

--- a/public/api/check_task.php
+++ b/public/api/check_task.php
@@ -1,0 +1,30 @@
+<?php
+declare(strict_types=1);
+
+$maybeConfig = __DIR__ . '/config.php';
+if (file_exists($maybeConfig)) {
+    require_once $maybeConfig;
+}
+require_once __DIR__ . '/dashscope_client.php';
+
+header('Content-Type: application/json');
+
+try {
+    $taskId = $_GET['taskId'] ?? '';
+    if ($taskId === '') {
+        throw new RuntimeException('El taskId es obligatorio.');
+    }
+
+    $response = dashscope_get_task($taskId);
+
+    echo json_encode([
+        'success' => true,
+        'data' => $response,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => $e->getMessage(),
+    ]);
+}

--- a/public/api/check_task.php
+++ b/public/api/check_task.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-$maybeConfig = __DIR__ . '/config.php';
-if (file_exists($maybeConfig)) {
-    require_once $maybeConfig;
-}
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/dashscope_client.php';
 
 header('Content-Type: application/json');

--- a/public/api/config.sample.php
+++ b/public/api/config.sample.php
@@ -5,3 +5,15 @@
 if (!defined('DASH_SCOPE_API_KEY')) {
     define('DASH_SCOPE_API_KEY', 'YOUR_DASHSCOPE_API_KEY_HERE');
 }
+
+// Opcional: descomenta para forzar otra URL base (por ejemplo, edición China).
+// define('DASH_SCOPE_API_ENDPOINT', 'https://dashscope.aliyuncs.com/api/v1');
+
+// Opcional: redefine rutas para crear o consultar tareas si tu cuenta usa endpoints distintos.
+// $DASH_SCOPE_VIDEO_TASK_CREATE_PATHS = [
+//     'services/aigc/video-generation/tasks',
+// ];
+// $DASH_SCOPE_VIDEO_TASK_STATUS_PATHS = [
+//     'services/aigc/video-generation/tasks/%s',
+//     'services/aigc/video-generation/tasks?task_id=%s',
+// ];

--- a/public/api/config.sample.php
+++ b/public/api/config.sample.php
@@ -1,5 +1,5 @@
 <?php
 // Copy this file to config.php and add your DashScope International API key.
-// You can also set the DASHSCOPE_API_KEY environment variable instead.
+// You can also set the DASH_SCOPE_API_KEY or DASHSCOPE_API_KEY environment variables instead.
 
 define('DASH_SCOPE_API_KEY', 'YOUR_DASHSCOPE_API_KEY_HERE');

--- a/public/api/config.sample.php
+++ b/public/api/config.sample.php
@@ -1,5 +1,6 @@
 <?php
 // Copy this file to config.php and add your DashScope International API key.
 // You can also set the DASH_SCOPE_API_KEY or DASHSCOPE_API_KEY environment variables instead.
-
-define('DASH_SCOPE_API_KEY', 'YOUR_DASHSCOPE_API_KEY_HERE');
+if (!defined('DASH_SCOPE_API_KEY')) {
+    define('DASH_SCOPE_API_KEY', 'YOUR_DASHSCOPE_API_KEY_HERE');
+}

--- a/public/api/config.sample.php
+++ b/public/api/config.sample.php
@@ -17,3 +17,7 @@ if (!defined('DASH_SCOPE_API_KEY')) {
 //     'services/aigc/video-generation/tasks/%s',
 //     'services/aigc/video-generation/tasks?task_id=%s',
 // ];
+
+// Opcional: redefine los modelos WAN si recibes "Model not exist" (acepta string o arreglo).
+// $DASH_SCOPE_MODEL_T2V = ['wanx-v1.1-t2v', 'wanx-v1-t2v'];
+// $DASH_SCOPE_MODEL_I2V = 'wanx-v1.2-i2v';

--- a/public/api/config.sample.php
+++ b/public/api/config.sample.php
@@ -1,6 +1,7 @@
 <?php
 // Copy this file to config.php and add your DashScope International API key.
 // You can also set the DASH_SCOPE_API_KEY or DASHSCOPE_API_KEY environment variables instead.
+// If you can't use define(), you may alternatively set $DASH_SCOPE_API_KEY = '...';
 if (!defined('DASH_SCOPE_API_KEY')) {
     define('DASH_SCOPE_API_KEY', 'YOUR_DASHSCOPE_API_KEY_HERE');
 }

--- a/public/api/config.sample.php
+++ b/public/api/config.sample.php
@@ -1,0 +1,5 @@
+<?php
+// Copy this file to config.php and add your DashScope International API key.
+// You can also set the DASHSCOPE_API_KEY environment variable instead.
+
+define('DASH_SCOPE_API_KEY', 'YOUR_DASHSCOPE_API_KEY_HERE');

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -5,7 +5,7 @@
  */
 
 const DASH_SCOPE_API_ENDPOINT = 'https://dashscope-intl.aliyuncs.com/api/v1';
-const DASH_SCOPE_API_KEY_ENV = 'DASHSCOPE_API_KEY';
+const DASH_SCOPE_API_KEY_ENV_NAMES = ['DASH_SCOPE_API_KEY', 'DASHSCOPE_API_KEY'];
 
 // Models
 const DASH_SCOPE_MODEL_T2V = 'wanx-v1-t2v';
@@ -22,12 +22,14 @@ function dashscope_get_api_key(): string
         return DASH_SCOPE_API_KEY;
     }
 
-    $envValue = getenv(DASH_SCOPE_API_KEY_ENV);
-    if ($envValue) {
-        return $envValue;
+    foreach (DASH_SCOPE_API_KEY_ENV_NAMES as $envName) {
+        $envValue = getenv($envName);
+        if ($envValue) {
+            return $envValue;
+        }
     }
 
-    throw new RuntimeException('DashScope API key is not configured. Set DASH_SCOPE_API_KEY in api/config.php or DASHSCOPE_API_KEY env variable.');
+    throw new RuntimeException('DashScope API key is not configured. Define DASH_SCOPE_API_KEY in api/config.php or set the DASH_SCOPE_API_KEY/DASHSCOPE_API_KEY environment variable.');
 }
 
 /**

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -20,10 +20,40 @@ const DASH_SCOPE_MODEL_CHAT = 'qwen-max';
  */
 function dashscope_get_api_key(): string
 {
+    $normalise = static function ($value): ?string {
+        if (!is_string($value)) {
+            return null;
+        }
+
+        $trimmed = trim($value);
+        if ($trimmed === '' || strcasecmp($trimmed, 'YOUR_DASHSCOPE_API_KEY_HERE') === 0) {
+            return null;
+        }
+
+        return $trimmed;
+    };
+
     if (defined('DASH_SCOPE_API_KEY')) {
-        $constant = trim((string) DASH_SCOPE_API_KEY);
-        if ($constant !== '' && strcasecmp($constant, 'YOUR_DASHSCOPE_API_KEY_HERE') !== 0) {
+        $constant = $normalise((string) DASH_SCOPE_API_KEY);
+        if ($constant !== null) {
             return $constant;
+        }
+    }
+
+    $globalSources = [
+        $GLOBALS['DASH_SCOPE_API_KEY'] ?? null,
+        $GLOBALS['dash_scope_api_key'] ?? null,
+    ];
+
+    if (isset($GLOBALS['config']) && is_array($GLOBALS['config'])) {
+        $globalSources[] = $GLOBALS['config']['DASH_SCOPE_API_KEY'] ?? null;
+        $globalSources[] = $GLOBALS['config']['dash_scope_api_key'] ?? null;
+    }
+
+    foreach ($globalSources as $value) {
+        $candidate = $normalise($value);
+        if ($candidate !== null) {
+            return $candidate;
         }
     }
 
@@ -35,16 +65,14 @@ function dashscope_get_api_key(): string
         ];
 
         foreach ($sources as $value) {
-            if (is_string($value)) {
-                $trimmed = trim($value);
-                if ($trimmed !== '') {
-                    return $trimmed;
-                }
+            $candidate = $normalise($value);
+            if ($candidate !== null) {
+                return $candidate;
             }
         }
     }
 
-    throw new RuntimeException('DashScope API key is not configured. Define DASH_SCOPE_API_KEY in api/config.php or set the DASH_SCOPE_API_KEY/DASHSCOPE_API_KEY environment variable.');
+    throw new RuntimeException('DashScope API key is not configured. Define DASH_SCOPE_API_KEY (o una variable $DASH_SCOPE_API_KEY) en api/config.php o configura las variables de entorno DASH_SCOPE_API_KEY/DASHSCOPE_API_KEY.');
 }
 
 /**

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -6,8 +6,54 @@
 
 require_once __DIR__ . '/bootstrap.php';
 
-const DASH_SCOPE_API_ENDPOINT = 'https://dashscope-intl.aliyuncs.com/api/v1';
 const DASH_SCOPE_API_KEY_ENV_NAMES = ['DASH_SCOPE_API_KEY', 'DASHSCOPE_API_KEY'];
+
+if (!function_exists('dashscope_config_value')) {
+    /**
+     * Fetch configuration value from constants, globals or config arrays.
+     *
+     * @param string $name    Configuration key (case sensitive)
+     * @param mixed  $default Default value when not configured
+     *
+     * @return mixed
+     */
+    function dashscope_config_value(string $name, $default = null)
+    {
+        if (defined($name)) {
+            return constant($name);
+        }
+
+        if (array_key_exists($name, $GLOBALS ?? [])) {
+            return $GLOBALS[$name];
+        }
+
+        if (array_key_exists(strtolower($name), $GLOBALS ?? [])) {
+            return $GLOBALS[strtolower($name)];
+        }
+
+        if (isset($GLOBALS['config']) && is_array($GLOBALS['config'])) {
+            if (array_key_exists($name, $GLOBALS['config'])) {
+                return $GLOBALS['config'][$name];
+            }
+
+            if (array_key_exists(strtolower($name), $GLOBALS['config'])) {
+                return $GLOBALS['config'][strtolower($name)];
+            }
+        }
+
+        return $default;
+    }
+}
+
+$configuredEndpoint = dashscope_config_value('DASH_SCOPE_API_ENDPOINT', 'https://dashscope-intl.aliyuncs.com/api/v1');
+
+if (!defined('DASH_SCOPE_API_ENDPOINT')) {
+    if (!is_string($configuredEndpoint) || trim($configuredEndpoint) === '') {
+        $configuredEndpoint = 'https://dashscope-intl.aliyuncs.com/api/v1';
+    }
+
+    define('DASH_SCOPE_API_ENDPOINT', rtrim($configuredEndpoint, '/'));
+}
 
 // Models
 const DASH_SCOPE_MODEL_T2V = 'wanx-v1-t2v';
@@ -73,6 +119,57 @@ function dashscope_get_api_key(): string
     }
 
     throw new RuntimeException('DashScope API key is not configured. Define DASH_SCOPE_API_KEY (o una variable $DASH_SCOPE_API_KEY) en api/config.php o configura las variables de entorno DASH_SCOPE_API_KEY/DASHSCOPE_API_KEY.');
+}
+
+/**
+ * Normalise a list of API path overrides.
+ *
+ * @param mixed $value
+ * @return array<int, string>
+ */
+function dashscope_normalise_path_list($value): array
+{
+    if (is_string($value)) {
+        $value = [$value];
+    }
+
+    if (!is_array($value)) {
+        return [];
+    }
+
+    $normalised = [];
+    foreach ($value as $path) {
+        if (!is_string($path)) {
+            continue;
+        }
+
+        $trimmed = trim($path);
+        if ($trimmed === '') {
+            continue;
+        }
+
+        $normalised[] = ltrim($trimmed, '/');
+    }
+
+    return array_values(array_unique($normalised));
+}
+
+/**
+ * Merge configured path list with defaults, giving precedence to configured values.
+ *
+ * @param string               $configKey
+ * @param array<int, string>   $defaults
+ * @return array<int, string>
+ */
+function dashscope_collect_paths(string $configKey, array $defaults): array
+{
+    $configured = dashscope_normalise_path_list(dashscope_config_value($configKey));
+
+    if ($configured === []) {
+        return $defaults;
+    }
+
+    return array_values(array_unique(array_merge($configured, $defaults)));
 }
 
 /**
@@ -177,7 +274,31 @@ function dashscope_start_video_task(string $mode, array $payload): array
         ]
     ];
 
-    return dashscope_request('POST', 'videos', $body);
+    $paths = dashscope_collect_paths('DASH_SCOPE_VIDEO_TASK_CREATE_PATHS', [
+        'videos',
+        'videos/tasks',
+        'services/aigc/video-generation/tasks',
+    ]);
+
+    $lastException = null;
+
+    foreach ($paths as $path) {
+        try {
+            return dashscope_request('POST', $path, $body);
+        } catch (RuntimeException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+
+            $lastException = $e;
+        }
+    }
+
+    if ($lastException !== null) {
+        throw $lastException;
+    }
+
+    throw new RuntimeException('DashScope API error: no se pudo crear la tarea de video.');
 }
 
 /**
@@ -185,7 +306,45 @@ function dashscope_start_video_task(string $mode, array $payload): array
  */
 function dashscope_get_task(string $taskId): array
 {
-    return dashscope_request('GET', 'videos/' . urlencode($taskId));
+    $taskId = trim($taskId);
+    if ($taskId === '') {
+        throw new InvalidArgumentException('El taskId está vacío.');
+    }
+
+    $paths = dashscope_collect_paths('DASH_SCOPE_VIDEO_TASK_STATUS_PATHS', [
+        'videos/%s',
+        'videos/tasks/%s',
+        'videos/tasks?taskId=%s',
+        'videos/tasks?task_id=%s',
+        'videos?taskId=%s',
+        'videos?task_id=%s',
+        'services/aigc/video-generation/tasks/%s',
+        'services/aigc/video-generation/tasks?taskId=%s',
+        'services/aigc/video-generation/tasks?task_id=%s',
+    ]);
+
+    $encodedId = rawurlencode($taskId);
+    $lastException = null;
+
+    foreach ($paths as $pathTemplate) {
+        $path = strpos($pathTemplate, '%s') !== false ? sprintf($pathTemplate, $encodedId) : rtrim($pathTemplate, '/') . '/' . $encodedId;
+
+        try {
+            return dashscope_request('GET', $path);
+        } catch (RuntimeException $e) {
+            if ($e->getCode() !== 404) {
+                throw $e;
+            }
+
+            $lastException = $e;
+        }
+    }
+
+    if ($lastException !== null) {
+        throw $lastException;
+    }
+
+    throw new RuntimeException('DashScope API error: no se encontró la tarea solicitada.');
 }
 
 /**

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -116,17 +116,46 @@ function dashscope_request(string $method, string $path, ?array $body = null, ar
     $statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
     curl_close($ch);
 
-    $decoded = json_decode($response, true);
+    $trimmedResponse = trim((string) $response);
+    $decoded = null;
+
+    if ($trimmedResponse === '') {
+        $decoded = [];
+    } else {
+        $decoded = json_decode($response, true);
+    }
+
     if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
-        throw new RuntimeException('Failed to decode API response: ' . json_last_error_msg());
+        $preview = substr(preg_replace('/\s+/', ' ', $trimmedResponse), 0, 200);
+        $baseMessage = 'Failed to decode API response (HTTP ' . $statusCode . '): ' . json_last_error_msg();
+
+        if ($statusCode >= 400) {
+            $errorMessage = $baseMessage;
+            if ($preview !== '') {
+                $errorMessage .= ' - cuerpo devuelto: ' . $preview;
+            }
+
+            throw new RuntimeException($errorMessage, $statusCode);
+        }
+
+        $extra = $preview !== '' ? ' Respuesta: ' . $preview : '';
+        throw new RuntimeException($baseMessage . $extra);
     }
 
     if ($statusCode >= 400) {
-        $message = $decoded['message'] ?? ('HTTP ' . $statusCode);
+        $message = is_array($decoded) ? ($decoded['message'] ?? ('HTTP ' . $statusCode)) : ('HTTP ' . $statusCode);
+
+        if (!is_array($decoded)) {
+            $preview = substr(preg_replace('/\s+/', ' ', $trimmedResponse), 0, 200);
+            if ($preview !== '') {
+                $message .= ' - cuerpo devuelto: ' . $preview;
+            }
+        }
+
         throw new RuntimeException('DashScope API error: ' . $message, $statusCode);
     }
 
-    return $decoded;
+    return $decoded ?? [];
 }
 
 /**

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -173,6 +173,60 @@ function dashscope_collect_paths(string $configKey, array $defaults): array
 }
 
 /**
+ * Merge configured scalar values with defaults, giving precedence to configured values.
+ *
+ * @param string             $configKey
+ * @param array<int, string> $defaults
+ * @return array<int, string>
+ */
+function dashscope_collect_values(string $configKey, array $defaults): array
+{
+    $configured = dashscope_config_value($configKey);
+
+    if ($configured === null) {
+        return $defaults;
+    }
+
+    if (!is_array($configured)) {
+        $configured = [$configured];
+    }
+
+    $normalised = [];
+
+    foreach ($configured as $value) {
+        if (!is_string($value)) {
+            continue;
+        }
+
+        $trimmed = trim($value);
+
+        if ($trimmed === '') {
+            continue;
+        }
+
+        $normalised[] = $trimmed;
+    }
+
+    if ($normalised === []) {
+        return $defaults;
+    }
+
+    return array_values(array_unique(array_merge($normalised, $defaults)));
+}
+
+/**
+ * Detect if the exception was caused by an invalid or missing model.
+ */
+function dashscope_is_missing_model_error(Throwable $exception): bool
+{
+    $message = $exception->getMessage();
+
+    return stripos($message, 'model not exist') !== false
+        || stripos($message, 'model not found') !== false
+        || stripos($message, 'invalid model') !== false;
+}
+
+/**
  * Perform HTTP request to DashScope.
  */
 function dashscope_request(string $method, string $path, ?array $body = null, array $headers = []): array
@@ -264,15 +318,22 @@ function dashscope_request(string $method, string $path, ?array $body = null, ar
  */
 function dashscope_start_video_task(string $mode, array $payload): array
 {
-    $model = $mode === 'i2v' ? DASH_SCOPE_MODEL_I2V : DASH_SCOPE_MODEL_T2V;
-
-    $body = [
-        'model' => $model,
-        'input' => $payload,
-        'parameters' => [
-            'mode' => $mode
+    $defaultModels = $mode === 'i2v'
+        ? [
+            DASH_SCOPE_MODEL_I2V,
+            'wanx-v1.1-i2v',
+            'wanx-v1.2-i2v',
+            'wan-v1-i2v',
         ]
-    ];
+        : [
+            DASH_SCOPE_MODEL_T2V,
+            'wanx-v1.1-t2v',
+            'wanx-v1.2-t2v',
+            'wan-v1-t2v',
+        ];
+
+    $modelKey = $mode === 'i2v' ? 'DASH_SCOPE_MODEL_I2V' : 'DASH_SCOPE_MODEL_T2V';
+    $models = dashscope_collect_values($modelKey, $defaultModels);
 
     $paths = dashscope_collect_paths('DASH_SCOPE_VIDEO_TASK_CREATE_PATHS', [
         'videos',
@@ -282,15 +343,25 @@ function dashscope_start_video_task(string $mode, array $payload): array
 
     $lastException = null;
 
-    foreach ($paths as $path) {
-        try {
-            return dashscope_request('POST', $path, $body);
-        } catch (RuntimeException $e) {
-            if ($e->getCode() !== 404) {
-                throw $e;
-            }
+    foreach ($models as $model) {
+        $body = [
+            'model' => $model,
+            'input' => $payload,
+            'parameters' => [
+                'mode' => $mode,
+            ]
+        ];
 
-            $lastException = $e;
+        foreach ($paths as $path) {
+            try {
+                return dashscope_request('POST', $path, $body);
+            } catch (RuntimeException $e) {
+                if ($e->getCode() !== 404 && !dashscope_is_missing_model_error($e)) {
+                    throw $e;
+                }
+
+                $lastException = $e;
+            }
         }
     }
 

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -23,9 +23,19 @@ function dashscope_get_api_key(): string
     }
 
     foreach (DASH_SCOPE_API_KEY_ENV_NAMES as $envName) {
-        $envValue = getenv($envName);
-        if ($envValue) {
-            return $envValue;
+        $sources = [
+            getenv($envName),
+            $_ENV[$envName] ?? null,
+            $_SERVER[$envName] ?? null,
+        ];
+
+        foreach ($sources as $value) {
+            if (is_string($value)) {
+                $trimmed = trim($value);
+                if ($trimmed !== '') {
+                    return $trimmed;
+                }
+            }
         }
     }
 

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -4,6 +4,8 @@
  * Update DASH_SCOPE_API_KEY in the generated config.php or via environment variable.
  */
 
+require_once __DIR__ . '/bootstrap.php';
+
 const DASH_SCOPE_API_ENDPOINT = 'https://dashscope-intl.aliyuncs.com/api/v1';
 const DASH_SCOPE_API_KEY_ENV_NAMES = ['DASH_SCOPE_API_KEY', 'DASHSCOPE_API_KEY'];
 
@@ -18,8 +20,11 @@ const DASH_SCOPE_MODEL_CHAT = 'qwen-max';
  */
 function dashscope_get_api_key(): string
 {
-    if (defined('DASH_SCOPE_API_KEY') && DASH_SCOPE_API_KEY) {
-        return DASH_SCOPE_API_KEY;
+    if (defined('DASH_SCOPE_API_KEY')) {
+        $constant = trim((string) DASH_SCOPE_API_KEY);
+        if ($constant !== '' && strcasecmp($constant, 'YOUR_DASHSCOPE_API_KEY_HERE') !== 0) {
+            return $constant;
+        }
     }
 
     foreach (DASH_SCOPE_API_KEY_ENV_NAMES as $envName) {

--- a/public/api/dashscope_client.php
+++ b/public/api/dashscope_client.php
@@ -1,0 +1,133 @@
+<?php
+/**
+ * Simple DashScope International client wrapper for shared hosting.
+ * Update DASH_SCOPE_API_KEY in the generated config.php or via environment variable.
+ */
+
+const DASH_SCOPE_API_ENDPOINT = 'https://dashscope-intl.aliyuncs.com/api/v1';
+const DASH_SCOPE_API_KEY_ENV = 'DASHSCOPE_API_KEY';
+
+// Models
+const DASH_SCOPE_MODEL_T2V = 'wanx-v1-t2v';
+const DASH_SCOPE_MODEL_I2V = 'wanx-v1-i2v';
+const DASH_SCOPE_MODEL_CHAT = 'qwen-max';
+
+/**
+ * Load API key from config or environment.
+ * Shared hosting friendly: use config.php to set constant.
+ */
+function dashscope_get_api_key(): string
+{
+    if (defined('DASH_SCOPE_API_KEY') && DASH_SCOPE_API_KEY) {
+        return DASH_SCOPE_API_KEY;
+    }
+
+    $envValue = getenv(DASH_SCOPE_API_KEY_ENV);
+    if ($envValue) {
+        return $envValue;
+    }
+
+    throw new RuntimeException('DashScope API key is not configured. Set DASH_SCOPE_API_KEY in api/config.php or DASHSCOPE_API_KEY env variable.');
+}
+
+/**
+ * Perform HTTP request to DashScope.
+ */
+function dashscope_request(string $method, string $path, ?array $body = null, array $headers = []): array
+{
+    $url = rtrim(DASH_SCOPE_API_ENDPOINT, '/') . '/' . ltrim($path, '/');
+    $ch = curl_init($url);
+    $defaultHeaders = [
+        'Authorization: Bearer ' . dashscope_get_api_key(),
+        'Content-Type: application/json'
+    ];
+
+    $payload = null;
+    if ($body !== null) {
+        $payload = json_encode($body);
+        if ($payload === false) {
+            throw new RuntimeException('Failed to encode request body.');
+        }
+    }
+
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_CUSTOMREQUEST => strtoupper($method),
+        CURLOPT_HTTPHEADER => array_merge($defaultHeaders, $headers),
+        CURLOPT_TIMEOUT => 120,
+    ]);
+
+    if ($payload !== null) {
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $payload);
+    }
+
+    $response = curl_exec($ch);
+    if ($response === false) {
+        $err = curl_error($ch);
+        curl_close($ch);
+        throw new RuntimeException('CURL error: ' . $err);
+    }
+
+    $statusCode = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+    curl_close($ch);
+
+    $decoded = json_decode($response, true);
+    if ($decoded === null && json_last_error() !== JSON_ERROR_NONE) {
+        throw new RuntimeException('Failed to decode API response: ' . json_last_error_msg());
+    }
+
+    if ($statusCode >= 400) {
+        $message = $decoded['message'] ?? ('HTTP ' . $statusCode);
+        throw new RuntimeException('DashScope API error: ' . $message, $statusCode);
+    }
+
+    return $decoded;
+}
+
+/**
+ * Start an asynchronous video generation task.
+ *
+ * @param string $mode Either 't2v' or 'i2v'
+ * @param array $payload Additional payload keys depending on the mode
+ * @return array
+ */
+function dashscope_start_video_task(string $mode, array $payload): array
+{
+    $model = $mode === 'i2v' ? DASH_SCOPE_MODEL_I2V : DASH_SCOPE_MODEL_T2V;
+
+    $body = [
+        'model' => $model,
+        'input' => $payload,
+        'parameters' => [
+            'mode' => $mode
+        ]
+    ];
+
+    return dashscope_request('POST', 'videos', $body);
+}
+
+/**
+ * Retrieve asynchronous task status.
+ */
+function dashscope_get_task(string $taskId): array
+{
+    return dashscope_request('GET', 'videos/' . urlencode($taskId));
+}
+
+/**
+ * Execute a synchronous chat completion request using Qwen.
+ */
+function dashscope_chat(string $prompt, ?string $systemPrompt = null): array
+{
+    $body = [
+        'model' => DASH_SCOPE_MODEL_CHAT,
+        'input' => [
+            'messages' => array_values(array_filter([
+                $systemPrompt ? ['role' => 'system', 'content' => $systemPrompt] : null,
+                ['role' => 'user', 'content' => $prompt]
+            ]))
+        ]
+    ];
+
+    return dashscope_request('POST', 'chat/completions', $body);
+}

--- a/public/api/start_task.php
+++ b/public/api/start_task.php
@@ -1,0 +1,73 @@
+<?php
+declare(strict_types=1);
+
+$maybeConfig = __DIR__ . '/config.php';
+if (file_exists($maybeConfig)) {
+    require_once $maybeConfig;
+}
+require_once __DIR__ . '/dashscope_client.php';
+
+header('Content-Type: application/json');
+
+try {
+    if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+        throw new RuntimeException('Invalid request method.');
+    }
+
+    $mode = $_POST['mode'] ?? '';
+    if (!in_array($mode, ['t2v', 'i2v'], true)) {
+        throw new RuntimeException('Modo inválido.');
+    }
+
+    $prompt = trim($_POST['prompt'] ?? '');
+    if ($prompt === '') {
+        throw new RuntimeException('El prompt es obligatorio.');
+    }
+
+    $format = $_POST['format'] ?? 'youtube';
+    $formatMap = [
+        'youtube' => ['aspect_ratio' => '16:9', 'resolution' => '1920x1080'],
+        'tiktok' => ['aspect_ratio' => '9:16', 'resolution' => '1080x1920'],
+        'square' => ['aspect_ratio' => '1:1', 'resolution' => '1080x1080'],
+    ];
+
+    $videoConfig = $formatMap[$format] ?? $formatMap['youtube'];
+
+    $payload = [
+        'prompt' => $prompt,
+        'video' => [
+            'aspect_ratio' => $videoConfig['aspect_ratio'],
+            'resolution' => $videoConfig['resolution'],
+        ],
+    ];
+
+    if ($mode === 'i2v') {
+        if (!isset($_FILES['image']) || $_FILES['image']['error'] !== UPLOAD_ERR_OK) {
+            throw new RuntimeException('Debes subir una imagen válida.');
+        }
+        $tmpPath = $_FILES['image']['tmp_name'];
+        $mimeType = mime_content_type($tmpPath) ?: 'image/png';
+        $content = base64_encode(file_get_contents($tmpPath));
+        $payload['image'] = [
+            'filename' => $_FILES['image']['name'],
+            'content' => 'data:' . $mimeType . ';base64,' . $content,
+        ];
+    }
+
+    if (!empty($_POST['negative_prompt'])) {
+        $payload['negative_prompt'] = trim($_POST['negative_prompt']);
+    }
+
+    $response = dashscope_start_video_task($mode, $payload);
+
+    echo json_encode([
+        'success' => true,
+        'data' => $response,
+    ]);
+} catch (Throwable $e) {
+    http_response_code(400);
+    echo json_encode([
+        'success' => false,
+        'error' => $e->getMessage(),
+    ]);
+}

--- a/public/api/start_task.php
+++ b/public/api/start_task.php
@@ -1,10 +1,7 @@
 <?php
 declare(strict_types=1);
 
-$maybeConfig = __DIR__ . '/config.php';
-if (file_exists($maybeConfig)) {
-    require_once $maybeConfig;
-}
+require_once __DIR__ . '/bootstrap.php';
 require_once __DIR__ . '/dashscope_client.php';
 
 header('Content-Type: application/json');

--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -1,0 +1,273 @@
+:root {
+  --bg: #0f172a;
+  --card-bg: rgba(15, 23, 42, 0.85);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --text: #f8fafc;
+  --muted: #94a3b8;
+  --danger: #f87171;
+  --success: #34d399;
+  font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: radial-gradient(circle at top, rgba(14, 116, 144, 0.35), transparent 55%),
+    linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(15, 23, 42, 0.9));
+  color: var(--text);
+  min-height: 100vh;
+}
+
+.app-container {
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 2.5rem 1.5rem 4rem;
+}
+
+header {
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: center;
+  margin-bottom: 2.5rem;
+}
+
+h1 {
+  font-size: clamp(2rem, 3vw, 2.6rem);
+  font-weight: 700;
+  margin: 0;
+}
+
+.subtitle {
+  color: var(--muted);
+  max-width: 560px;
+  line-height: 1.5;
+}
+
+nav {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.tab-button {
+  padding: 0.75rem 1.4rem;
+  border-radius: 999px;
+  border: 1px solid transparent;
+  background: rgba(148, 163, 184, 0.12);
+  color: var(--text);
+  cursor: pointer;
+  transition: all 0.2s ease;
+  font-weight: 600;
+}
+
+.tab-button.active,
+.tab-button:hover {
+  background: rgba(56, 189, 248, 0.18);
+  border-color: rgba(14, 165, 233, 0.6);
+  color: var(--text);
+}
+
+.panels {
+  display: grid;
+  gap: 2rem;
+}
+
+.panel {
+  background: var(--card-bg);
+  border-radius: 24px;
+  padding: 2rem;
+  box-shadow: 0 32px 60px rgba(15, 23, 42, 0.25);
+  border: 1px solid rgba(148, 163, 184, 0.16);
+  backdrop-filter: blur(18px);
+}
+
+.panel h2 {
+  margin-top: 0;
+  font-size: 1.45rem;
+}
+
+form {
+  display: grid;
+  gap: 1.2rem;
+}
+
+label {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+  font-weight: 600;
+}
+
+textarea,
+input[type="text"],
+input[type="file"],
+select {
+  width: 100%;
+  padding: 0.9rem 1rem;
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--text);
+  font-size: 1rem;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+textarea:focus,
+input[type="text"]:focus,
+select:focus {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+  outline: none;
+}
+
+textarea {
+  min-height: 140px;
+  resize: vertical;
+}
+
+.button-primary {
+  background: linear-gradient(135deg, var(--accent), var(--accent-strong));
+  color: var(--text);
+  border: none;
+  padding: 0.9rem 1.6rem;
+  border-radius: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.button-primary:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 30px rgba(14, 165, 233, 0.3);
+}
+
+.button-secondary {
+  border-radius: 14px;
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: transparent;
+  color: var(--muted);
+  padding: 0.8rem 1.4rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.status-card {
+  margin-top: 1.5rem;
+  padding: 1.2rem 1.4rem;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: none;
+  gap: 0.6rem;
+}
+
+.status-card.visible {
+  display: grid;
+}
+
+.status-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  font-weight: 600;
+}
+
+.status-progress {
+  position: relative;
+  width: 100%;
+  height: 10px;
+  background: rgba(148, 163, 184, 0.2);
+  border-radius: 999px;
+  overflow: hidden;
+  margin: 0.6rem 0;
+}
+
+.status-progress .bar {
+  position: absolute;
+  inset: 0;
+  width: 25%;
+  background: linear-gradient(90deg, var(--accent), var(--accent-strong));
+  animation: progress-indeterminate 1.1s infinite;
+}
+
+@keyframes progress-indeterminate {
+  0% {
+    transform: translateX(-100%);
+  }
+  50% {
+    transform: translateX(0%);
+  }
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.status-message {
+  font-size: 0.95rem;
+  color: var(--muted);
+}
+
+.status-message.error {
+  color: var(--danger);
+}
+
+.video-result {
+  margin-top: 1rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.video-result a {
+  color: var(--accent);
+  word-break: break-all;
+}
+
+.chat-history {
+  background: rgba(15, 23, 42, 0.65);
+  border-radius: 18px;
+  padding: 1.2rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  max-height: 380px;
+  overflow-y: auto;
+  display: grid;
+  gap: 1rem;
+}
+
+.chat-bubble {
+  padding: 0.9rem 1rem;
+  border-radius: 16px;
+  line-height: 1.5;
+  white-space: pre-line;
+}
+
+.chat-bubble.user {
+  background: rgba(56, 189, 248, 0.15);
+  justify-self: end;
+}
+
+.chat-bubble.assistant {
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.14);
+}
+
+@media (max-width: 768px) {
+  header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  nav {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  .panel {
+    padding: 1.5rem;
+  }
+}

--- a/public/assets/js/app.js
+++ b/public/assets/js/app.js
@@ -1,0 +1,203 @@
+const tabButtons = document.querySelectorAll('.tab-button');
+const panels = document.querySelectorAll('.panel');
+
+function selectTab(targetId) {
+  panels.forEach(panel => {
+    panel.style.display = panel.id === targetId ? 'block' : 'none';
+  });
+  tabButtons.forEach(btn => {
+    if (btn.dataset.target === targetId) {
+      btn.classList.add('active');
+    } else {
+      btn.classList.remove('active');
+    }
+  });
+}
+
+tabButtons.forEach(btn => {
+  btn.addEventListener('click', () => selectTab(btn.dataset.target));
+});
+
+selectTab('panel-t2v');
+
+function buildStatusController(wrapper) {
+  const card = wrapper.querySelector('.status-card');
+  const message = wrapper.querySelector('.status-message');
+  const result = wrapper.querySelector('.video-result');
+
+  function show(msg, isError = false) {
+    if (!card || !message) return;
+    card.classList.add('visible');
+    message.textContent = msg;
+    message.classList.toggle('error', isError);
+  }
+
+  function hide() {
+    if (!card) return;
+    card.classList.remove('visible');
+  }
+
+  function showResult(videoUrl, raw) {
+    if (!result) return;
+    result.innerHTML = '';
+    const link = document.createElement('a');
+    link.href = videoUrl;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.textContent = 'Descargar / Ver video generado';
+    result.appendChild(link);
+
+    if (raw) {
+      const details = document.createElement('details');
+      const summary = document.createElement('summary');
+      summary.textContent = 'Ver respuesta completa de la API';
+      details.appendChild(summary);
+      const pre = document.createElement('pre');
+      pre.textContent = JSON.stringify(raw, null, 2);
+      details.appendChild(pre);
+      result.appendChild(details);
+    }
+  }
+
+  return { show, hide, showResult };
+}
+
+async function startTask(form, mode) {
+  const controller = buildStatusController(form.closest('.panel'));
+  controller.show('Enviando solicitud a DashScope…');
+
+  const formData = new FormData(form);
+  formData.append('mode', mode);
+
+  try {
+    const response = await fetch('api/start_task.php', {
+      method: 'POST',
+      body: formData,
+    });
+
+    const data = await response.json();
+    if (!response.ok || !data.success) {
+      throw new Error(data.error || 'No se pudo iniciar la tarea.');
+    }
+
+    const output = data.data?.output || data.data;
+    const taskId = output?.task_id || output?.taskId || data.data?.task_id;
+    if (!taskId) {
+      throw new Error('No se recibió un task_id. Revisa tu clave API o parámetros.');
+    }
+
+    controller.show(`Tarea creada (#${taskId}). Procesando video…`);
+    pollTask(taskId, controller);
+  } catch (error) {
+    console.error(error);
+    controller.show(error.message, true);
+  }
+}
+
+async function pollTask(taskId, controller) {
+  const poll = async () => {
+    try {
+      const response = await fetch(`api/check_task.php?taskId=${encodeURIComponent(taskId)}`);
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Error al consultar el estado.');
+      }
+
+      const payload = data.data;
+      const status = payload.status || payload.task_status || payload.output?.task_status;
+      const message = payload.message || payload.output?.message || `Estado: ${status}`;
+
+      if (!status) {
+        controller.show('Esperando respuesta de DashScope…');
+        setTimeout(poll, 4000);
+        return;
+      }
+
+      if (['PROCESSING', 'PENDING', 'RUNNING'].includes(status.toUpperCase())) {
+        controller.show(message || `Procesando (${status})…`);
+        setTimeout(poll, 4500);
+        return;
+      }
+
+      if (status.toUpperCase() === 'SUCCEEDED') {
+        const videoUrl = payload.output?.video_url || payload.video_url || '';
+        if (!videoUrl) {
+          controller.show('Tarea completada pero no se recibió URL de video.', true);
+        } else {
+          controller.show('¡Video listo! Descarga disponible abajo.');
+          controller.showResult(videoUrl, payload);
+        }
+        return;
+      }
+
+      if (status.toUpperCase() === 'FAILED') {
+        const errMsg = payload.output?.error || payload.error || 'La generación falló.';
+        controller.show(`Error: ${errMsg}`, true);
+        return;
+      }
+
+      controller.show(message || `Estado: ${status}`);
+      setTimeout(poll, 5000);
+    } catch (error) {
+      controller.show(error.message, true);
+    }
+  };
+
+  poll();
+}
+
+const t2vForm = document.getElementById('t2v-form');
+if (t2vForm) {
+  t2vForm.addEventListener('submit', event => {
+    event.preventDefault();
+    startTask(t2vForm, 't2v');
+  });
+}
+
+const i2vForm = document.getElementById('i2v-form');
+if (i2vForm) {
+  i2vForm.addEventListener('submit', event => {
+    event.preventDefault();
+    startTask(i2vForm, 'i2v');
+  });
+}
+
+const chatForm = document.getElementById('chat-form');
+const chatHistory = document.querySelector('.chat-history');
+
+function appendChatBubble(text, role) {
+  if (!chatHistory) return;
+  const bubble = document.createElement('div');
+  bubble.className = `chat-bubble ${role}`;
+  bubble.textContent = text;
+  chatHistory.appendChild(bubble);
+  chatHistory.scrollTop = chatHistory.scrollHeight;
+}
+
+if (chatForm) {
+  chatForm.addEventListener('submit', async event => {
+    event.preventDefault();
+    const input = chatForm.querySelector('textarea[name="message"]');
+    const system = chatForm.querySelector('input[name="system"]');
+    const message = input.value.trim();
+    if (!message) return;
+
+    appendChatBubble(message, 'user');
+    input.value = '';
+
+    try {
+      const response = await fetch('api/chat.php', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message, system: system?.value || '' }),
+      });
+      const data = await response.json();
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'No se pudo obtener la respuesta.');
+      }
+      appendChatBubble(data.message || 'Sin respuesta.', 'assistant');
+    } catch (error) {
+      appendChatBubble(`⚠️ ${error.message}`, 'assistant');
+    }
+  });
+}

--- a/public/index.php
+++ b/public/index.php
@@ -1,0 +1,121 @@
+<?php
+declare(strict_types=1);
+
+$maybeConfig = __DIR__ . '/api/config.php';
+if (file_exists($maybeConfig)) {
+    require_once $maybeConfig;
+}
+?>
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Generador WAN - DashScope Internacional</title>
+  <link rel="stylesheet" href="assets/css/style.css" />
+</head>
+<body>
+  <div class="app-container">
+    <header>
+      <div>
+        <h1>WAN Video Studio</h1>
+        <p class="subtitle">Genera videos con modelos WAN i2v y t2v de DashScope International y chatea con Qwen en un mismo panel optimizado para hosting compartido.</p>
+      </div>
+      <nav>
+        <button class="tab-button" data-target="panel-t2v">Texto → Video</button>
+        <button class="tab-button" data-target="panel-i2v">Imagen → Video</button>
+        <button class="tab-button" data-target="panel-chat">Chat Qwen</button>
+      </nav>
+    </header>
+
+    <section class="panels">
+      <article class="panel" id="panel-t2v">
+        <h2>Texto → Video (WAN t2v)</h2>
+        <form id="t2v-form">
+          <label>
+            Prompt principal
+            <textarea name="prompt" placeholder="Describe la escena, estilo, iluminación…" required></textarea>
+          </label>
+          <label>
+            Formato de salida
+            <select name="format">
+              <option value="youtube">YouTube (16:9, 1080p)</option>
+              <option value="tiktok">TikTok / Reels (9:16, 1080x1920)</option>
+              <option value="square">Cuadrado (1:1, 1080x1080)</option>
+            </select>
+          </label>
+          <label>
+            Prompt negativo (opcional)
+            <input type="text" name="negative_prompt" placeholder="Qué quieres evitar en el video" />
+          </label>
+          <button class="button-primary" type="submit">Generar video</button>
+        </form>
+        <div class="status-card">
+          <div class="status-header">
+            <span>Estado del trabajo</span>
+          </div>
+          <div class="status-progress"><span class="bar"></span></div>
+          <span class="status-message">Esperando…</span>
+          <div class="video-result"></div>
+        </div>
+      </article>
+
+      <article class="panel" id="panel-i2v" style="display:none;">
+        <h2>Imagen → Video (WAN i2v)</h2>
+        <form id="i2v-form" enctype="multipart/form-data">
+          <label>
+            Prompt principal
+            <textarea name="prompt" placeholder="Explica qué debe ocurrir en la animación" required></textarea>
+          </label>
+          <label>
+            Imagen inicial
+            <input type="file" name="image" accept="image/*" required />
+          </label>
+          <label>
+            Formato de salida
+            <select name="format">
+              <option value="youtube">YouTube (16:9, 1080p)</option>
+              <option value="tiktok">TikTok / Reels (9:16, 1080x1920)</option>
+              <option value="square">Cuadrado (1:1, 1080x1080)</option>
+            </select>
+          </label>
+          <label>
+            Prompt negativo (opcional)
+            <input type="text" name="negative_prompt" placeholder="Qué quieres evitar en el video" />
+          </label>
+          <button class="button-primary" type="submit">Animar imagen</button>
+        </form>
+        <div class="status-card">
+          <div class="status-header">
+            <span>Estado del trabajo</span>
+          </div>
+          <div class="status-progress"><span class="bar"></span></div>
+          <span class="status-message">Esperando…</span>
+          <div class="video-result"></div>
+        </div>
+      </article>
+
+      <article class="panel" id="panel-chat" style="display:none;">
+        <h2>Chat Qwen en tiempo real</h2>
+        <div class="chat-history" aria-live="polite"></div>
+        <form id="chat-form">
+          <label>
+            Instrucción del sistema (opcional)
+            <input type="text" name="system" placeholder="Ej. Eres un asistente creativo" />
+          </label>
+          <label>
+            Mensaje
+            <textarea name="message" placeholder="Pregunta o describe qué necesitas" required></textarea>
+          </label>
+          <div style="display:flex; gap:1rem; flex-wrap:wrap; align-items:center;">
+            <button class="button-primary" type="submit">Enviar</button>
+            <button class="button-secondary" type="button" onclick="document.querySelector('.chat-history').innerHTML=''">Limpiar chat</button>
+          </div>
+        </form>
+      </article>
+    </section>
+  </div>
+
+  <script src="assets/js/app.js" defer></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add PHP front-end for DashScope WAN text-to-video, image-to-video, and Qwen chat workflows
- implement shared dashscope client helpers for asynchronous task creation and status polling
- style the single-page app with modern UI, progress indicators, and error reporting

## Testing
- find public -name '*.php' -print0 | xargs -0 -n1 php -l

------
https://chatgpt.com/codex/tasks/task_e_68eec6ff35dc832c920bee5dc94c522f